### PR TITLE
C++11 using http://docs.travis-ci.com/user/apt/

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ addons:
   apt:
     sources:
     - ubuntu-toolchain-r-test
-addons:
-  apt:
     packages:
     - libyajl-dev
     - libxml2-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ script:
   - make init-submodule 
   - make
   - make check
-compiler: gcc
+compiler:
+  - gcc
+  - clang
 before_install:
 #- sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
 #- sudo apt-get update -qq
@@ -20,6 +22,7 @@ addons:
     - libxml2-dev
     - gcc-4.8
     - g++-4.8
+    - clang
 #   - libxqilla
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,23 @@ script:
   - make check
 compiler: gcc
 before_install:
-- sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-- sudo apt-get update -qq
-- sudo apt-get install -qq libyajl-dev libxml2-dev libxqilla-dev
-- if [ "$CXX" = "clang++" ]; then sudo apt-get install -qq libstdc++-4.8-dev; fi
-- if [ "$CXX" = "g++" ]; then sudo apt-get install -qq g++-4.8; fi
+#- sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+#- sudo apt-get update -qq
+#- sudo apt-get install -qq libyajl-dev libxml2-dev libxqilla-dev
+#- if [ "$CXX" = "clang++" ]; then sudo apt-get install -qq libstdc++-4.8-dev; fi
+#- if [ "$CXX" = "g++" ]; then sudo apt-get install -qq g++-4.8; fi
 - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+addons:
+  apt:
+    packages:
+    - libyajl-dev
+    - libxml2-dev
+    - gcc-4.8
+    - g++-4.8
+#   - libxqilla
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,8 @@ script:
   - make check
 compiler:
   - gcc
-  - clang
-before_install:
-#- sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-#- sudo apt-get update -qq
-#- sudo apt-get install -qq libyajl-dev libxml2-dev libxqilla-dev
-#- if [ "$CXX" = "clang++" ]; then sudo apt-get install -qq libstdc++-4.8-dev; fi
-#- if [ "$CXX" = "g++" ]; then sudo apt-get install -qq g++-4.8; fi
+# - clang
+install:
 - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
 addons:
   apt:
@@ -23,6 +18,6 @@ addons:
     - gcc-4.8
     - g++-4.8
     - clang
-#   - libxqilla
+#   - libxqilla-dev # missing, but not needed?
 notifications:
   email: false


### PR DESCRIPTION
re: C++-11 via 7f4f3b9c292683c1255b73f2dbac080ecf5af528 in #6 

I see. The whole web wants C++11, but most people have only that hack.

I've found a better way to do this, which also evinced a bug in Travis docs, which Travis support [is fixing](https://github.com/travis-ci/docs-travis-ci-com/pull/266).

[**libxqilla**](http://xqilla.sourceforge.net/Documentation) is not [*whitelisted*](https://github.com/travis-ci/apt-package-whitelist/blob/master/ubuntu-precise), but I don't think we actually need that anymore.

Currently, [clang++ fails](https://travis-ci.org/pb-cdunn/pbdagcon/jobs/67426664), so we cannot add that to the build yet.

* https://github.com/solarce/pbdagcon/commit/5fe76b368d621b6c4cf5fba32d5de51c8d0c609a
* http://docs.travis-ci.com/user/apt/
* https://github.com/travis-ci/docs-travis-ci-com/pull/266
* https://github.com/travis-ci/travis-yaml/issues/64
* https://github.com/travis-ci/apt-package-whitelist/blob/master/ubuntu-precise
* https://travis-ci.org/pb-cdunn/pbdagcon/builds/67426662
* https://github.com/travis-ci/travis-ci/issues/1379
* https://github.com/travis-ci/travis-ci/issues/979