### PR TITLE
build in docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,4 @@ addons:
 #   - libxqilla-dev # missing, but not needed?
 notifications:
   email: false
+sudo: false


### PR DESCRIPTION
> RE: docker. Is that something we can even control? (#8)

Evidently!

```
Christopher,

Linux based builds that were activated before we made our Docker based
environment the default for Linux builds still build on the fully
virtualized environment. Newer repositories, like your fork, build on
our Docker based environment by default.

https://travis-ci.org/PacificBiosciences/pbdagcon/ was initial activated
on 2014-02-18 04:50:34 UTC, so it's getting routed to the fully
virtualized builders because of that.

If you add sudo: false to your travis.yml it'll always get sent to our
Docker based environment.

Thanks,

Brandon
```