### PR TITLE
GCC 4.8/std::thread bug workaround

### DIFF
--- a/src/cpp/Makefile
+++ b/src/cpp/Makefile
@@ -14,7 +14,7 @@ all: pbdagcon
 
 dazcon: LDLIBS = -lpthread
 dazcon: $(COMMON_OBJECTS) $(DAZCON_OBJECTS)
-	$(CXX) -Wl,--no-as-needed $(OPTIMIZE) -o $@ $^ $(LDLIBS)
+	$(CXX) -Wl,--no-as-needed -o $@ $^ $(LDLIBS)
 
 # We are moving to BAM, which requires extra lib support when compiling against
 # libblasr.  This conditional allows backward compatable compilations with 
@@ -26,7 +26,7 @@ pbdagcon: LDLIBS = -lpbdata -lblasr -lpbbam -lhts -lz -lpthread
 endif
 pbdagcon: CXXFLAGS += $(INCDIRS)
 pbdagcon: $(COMMON_OBJECTS) $(PBDAGCON_OBJECTS)
-	$(CXX) $(LIBDIRS) -static -o $@ $^ $(LDFLAGS) $(LDLIBS)
+	$(CXX) -Wl,--no-as-needed $(LIBDIRS) -o $@ $^ $(LDFLAGS) $(LDLIBS)
 
 $(COMMON_OBJECTS): $(BOOST_HEADERS)
 


### PR DESCRIPTION
https://bugs.launchpad.net/ubuntu/+source/gcc-defaults/+bug/1228201

This was causing statically compiled pbdagcon into a runtime segfault when running with one thread.
...
2015-06-26 08:05:43,255 DEBUG [Reader] [jdrake@unknown-host] [FUNCTION] [FILE:0] Consensus candidate: Backbone_1
2015-06-26 08:05:43,255 FATAL [default] CRASH HANDLED; Application has crashed due to [SIGSEGV] signal
2015-06-26 08:05:43,255 WARN  [default] Aborting application. Reason: Fatal log at [third-party/easylogging++.h:5583]

Multiple threads resulted in this:

terminate called after throwing an instance of 'std::system_error'
  what():  Enable multithreading to use std::thread: Operation not permitted
 