### PR TITLE
buildable both within PacBio and externally

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "blasr_libcpp"]
 	path = blasr_libcpp
-	url = https://github.com/PacificBiosciences/blasr_libcpp.git
+	url = https://github.com/pb-cdunn/blasr_libcpp.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ script:
   - make check
 compiler:
   - gcc
-# - clang
+  - clang
 install:
 - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
 addons:

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,11 @@ check: cpp-github-check
 project: init-submodule cpp-github
 
 init-submodule:
-	git submodule update --init
+	$(MAKE) update-submodule
 	$(MAKE) build-submodule
+
+update-submodule:
+	git submodule update --init
 
 build-submodule:
 	$(MAKE) -C blasr_libcpp/pbdata nopbbam=1 mklibconfig

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,10 @@ init-submodule:
 	$(MAKE) build-submodule
 
 build-submodule:
-	$(MAKE) -C blasr_libcpp/alignment nohdf=1
-	$(MAKE) -C blasr_libcpp/pbdata
+	$(MAKE) -C blasr_libcpp/pbdata nopbbam=1 mklibconfig
+	#$(MAKE) -C blasr_libcpp/pbdata mklibconfig
+	$(MAKE) -C blasr_libcpp/alignment -f simple.mk nohdf=1
+	$(MAKE) -C blasr_libcpp/pbdata nopbbam=1
 
 submodule-clean:
 	$(RM) -r blasr_libcpp

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ project: init-submodule cpp-github
 
 init-submodule:
 	git submodule update --init
+	$(MAKE) build-submodule
+
+build-submodule:
 	$(MAKE) -C blasr_libcpp/alignment nohdf=1
 	$(MAKE) -C blasr_libcpp/pbdata
 

--- a/README.md
+++ b/README.md
@@ -51,11 +51,12 @@ internet.
 
     # build pbdagcon executable (Makefile fetches boost headers)
     make
-    # You already have boost headers
+    # or, if you already have boost headers
     make boost=<path to headers>
 
     # build and run unit tests
-    make check
+    # THIS IS CURRENTLY BROKEN. -cdunn
+    ###make check
 
     # usage 
     cd src/cpp

--- a/README.md
+++ b/README.md
@@ -44,21 +44,23 @@ supply them yourself or the Makefile will obtain them for you from the
 internet.
 
 ### Compile/Check (pbdagcon)
+```sh
     # First fetch and build the relevant portions of the blasr_libcpp
     # submodule
-    > make init-submodule
+    make init-submodule
 
     # build pbdagcon executable (Makefile fetches boost headers)
-    > make
+    make
     # You already have boost headers
-    > make boost=<path to headers>
+    make boost=<path to headers>
 
     # build and run unit tests
-    > make check
+    make check
 
     # usage 
-    > cd src/cpp
-    > ./pbdagcon --help
+    cd src/cpp
+    ./pbdagcon --help
+```
 
 Running
 =======
@@ -71,13 +73,13 @@ At the most basic level, pbdagcon takes information from BLASR alignments
 sorted by target and generates fasta-formatted corrected target sequences.
 The alignments from BLASR can be formatted with either *-m 4* or *-m 5*. 
 For *-m 4* format, the alignments must be run through a format adapter, 
-*src/m4topre.py*, in order to generate suitable input to *pbdagcon*.
+*[m4topre.py][]*, in order to generate suitable input to *pbdagcon*.
 
 The following example shows the simplest way to generate a consensus for one 
 target using BLASR *-m 5* alignments as input.
 
-    > blasr queries.fasta target.fasta -bestn 1 -m 5 -out mapped.m5
-    > pbdagcon mapped.m5 > consensus.fasta
+    blasr queries.fasta target.fasta -bestn 1 -m 5 -out mapped.m5
+    pbdagcon mapped.m5 > consensus.fasta
 
 ### Use Case: Generating consensus from daligner alignments
 Can parse LAS/DB files generated from the following commits:
@@ -90,20 +92,20 @@ Walks through how one could use pbdagcon to correct PacBio reads.  This
 example demonstrates how correction is performed in PacBio's "Hierarchichal  
 Genome Assembly Process" (HGAP) workflow.  HGAP uses BLASR *-m 4* output.
 
-This example makes use of the *src/filterm4.py* and *src/m4topre.py* scripts.
-
+This example makes use of the *[filterm4.py][]* and *[m4topre.py][]* scripts:
+```sh
     # First filter the m4 file to help remove chimeras
-    > filterm4.py mapped.m4 > mapped.m4.filt
+    filterm4.py mapped.m4 > mapped.m4.filt
 
     # Next run the m4 adapter script, generating 'pre-alignments'
-    > m4topre.py mapped.m4.filt mapped.m4.filt reads.fasta 24 > mapped.pre
+    m4topre.py mapped.m4.filt mapped.m4.filt reads.fasta 24 > mapped.pre
 
     # Finally, correct using pbdagcon, typically using multiple consensus  
     # threads.
-    > pbdagcon -j 4 -a mapped.pre > corrected.fasta
+    pbdagcon -j 4 -a mapped.pre > corrected.fasta
+```
 
-The *src/cpp/pbdagcon_wf.sh* script automates this workflow.
-
+The *[pbdagcon_wf.sh][]* script automates this workflow.
 
 -----------------------------------------------------------------------------
 
@@ -115,3 +117,10 @@ m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 ga('create', 'UA-13166584-17', 'github.com');
 ga('send', 'pageview');
 </script>
+
+[m4topre.py]:
+  src/m4topre.py 'code'
+[filterm4.py]:
+  src/filterm4.py 'code'
+[pbdagcon_wf.sh]:
+  src/cpp/pbdagcon_wf.sh 'code'

--- a/src/cpp/BlasrM5AlnProvider.cpp
+++ b/src/cpp/BlasrM5AlnProvider.cpp
@@ -87,7 +87,7 @@ bool BlasrM5AlnProvider::nextTarget(std::vector<dagcon::Alignment>& dest) {
         dest.push_back(aln);
     }
 
-    return (*is_);
+    return bool(*is_);
 }
 
 bool BlasrM5AlnProvider::nextTarget(std::string& targetSeq, std::vector<dagcon::Alignment>& dest) {

--- a/src/cpp/Makefile
+++ b/src/cpp/Makefile
@@ -1,4 +1,11 @@
-include pbi.mk
+# Defines some variables specific to the PBI build env using relative paths
+BASEDIR  ?= ../../../../../..
+BIFX     := $(BASEDIR)/smrtanalysis/bioinformatics
+PBBAM    := $(BIFX)/staging/PostPrimary/pbbam
+# Conditionally include PBI overrides.
+ifneq ($(wildcard $(PBBAM)/*),)
+  include pbi.mk
+endif
 include boost.mk
 
 COMMON_OBJECTS := Alignment.o AlnGraphBoost.o
@@ -10,20 +17,16 @@ CXXFLAGS = -O3 -std=c++11 -Wall -Wuninitialized -pedantic -I third-party \
 
 CFLAGS = -O3 -Wall -Wextra -fno-strict-aliasing
 
+INCDIRS := -I$(PBDATA) -I$(BLASR) $(EXTRA_INCDIRS)
+LDFLAGS := -L$(PBDATA) -L$(BLASR) $(EXTRA_LDFLAGS)
+
 all: pbdagcon
 
 dazcon: LDLIBS = -lpthread
 dazcon: $(COMMON_OBJECTS) $(DAZCON_OBJECTS)
 	$(CXX) -Wl,--no-as-needed -o $@ $^ $(LDLIBS)
 
-# We are moving to BAM, which requires extra lib support when compiling against
-# libblasr.  This conditional allows backward compatable compilations with 
-# PacificBiosciences/blasr_libcpp.
-ifeq ($(wildcard $(PBBAM)/*),)
-pbdagcon: LDLIBS = -lpbdata -lblasr -lpthread
-else
-pbdagcon: LDLIBS = -lpbdata -lblasr -lpbbam -lhts -lz -lpthread
-endif
+pbdagcon: LDLIBS = -lpbdata -lblasr -lpthread $(EXTRA_LDLIBS)
 pbdagcon: CXXFLAGS += $(INCDIRS)
 pbdagcon: $(COMMON_OBJECTS) $(PBDAGCON_OBJECTS)
 	$(CXX) -Wl,--no-as-needed $(LIBDIRS) -o $@ $^ $(LDFLAGS) $(LDLIBS)

--- a/src/cpp/Makefile
+++ b/src/cpp/Makefile
@@ -1,11 +1,4 @@
-# Defines some variables specific to the PBI build env using relative paths
-BASEDIR  ?= ../../../../../..
-BIFX     := $(BASEDIR)/smrtanalysis/bioinformatics
-PBBAM    := $(BIFX)/staging/PostPrimary/pbbam
-# Conditionally include PBI overrides.
-ifneq ($(wildcard $(PBBAM)/*),)
-  include pbi.mk
-endif
+include pbi.mk
 include boost.mk
 
 COMMON_OBJECTS := Alignment.o AlnGraphBoost.o

--- a/src/cpp/pbi.mk
+++ b/src/cpp/pbi.mk
@@ -1,3 +1,7 @@
+# Darwin/Clang is unhappy with -L for a non-existent directory, so we
+# cannot use this file to build on OSX.
+# Instead of a bunch of ifdefs, we can conditionally include this file.
+
 # Defines some variables specific to the PBI build env using relative paths
 BASEDIR  ?= ../../../../../..
 PREBUILT := $(BASEDIR)/smrtanalysis/prebuilt.out
@@ -7,5 +11,10 @@ PBDATA   ?= $(BIFX)/lib/cpp/pbdata
 PBBAM    := $(BIFX)/staging/PostPrimary/pbbam
 ZLIB     := $(PREBUILT)/zlib/zlib-1.2.5/$(OS_STRING2)/lib
 
-INCDIRS := -I$(PBDATA) -I$(BLASR) -I$(PBBAM)/include -I$(PBBAM)/third-party/htslib
-LDFLAGS := -L$(PBDATA) -L$(BLASR) -L$(PBBAM)/lib -L$(PBBAM)/third-party/htslib -L$(ZLIB)
+EXTRA_INCDIRS := -I$(PBBAM)/include -I$(PBBAM)/third-party/htslib
+EXTRA_LDFLAGS := -L$(PBBAM)/lib -L$(PBBAM)/third-party/htslib -L$(ZLIB)
+
+# We are moving to BAM, which requires extra lib support when compiling against
+# libblasr.  This conditional allows backward compatable compilations with
+# PacificBiosciences/blasr_libcpp.
+EXTRA_LDLIBS = -lpbbam -lhts -lz -lpthread

--- a/src/cpp/pbi.mk
+++ b/src/cpp/pbi.mk
@@ -11,6 +11,7 @@ PBDATA   ?= $(BIFX)/lib/cpp/pbdata
 PBBAM    := $(BIFX)/staging/PostPrimary/pbbam
 ZLIB     := $(PREBUILT)/zlib/zlib-1.2.5/$(OS_STRING2)/lib
 
+ifneq ($(wildcard $(PBBAM)/*),)
 EXTRA_INCDIRS := -I$(PBBAM)/include -I$(PBBAM)/third-party/htslib
 EXTRA_LDFLAGS := -L$(PBBAM)/lib -L$(PBBAM)/third-party/htslib -L$(ZLIB)
 
@@ -18,3 +19,4 @@ EXTRA_LDFLAGS := -L$(PBBAM)/lib -L$(PBBAM)/third-party/htslib -L$(ZLIB)
 # libblasr.  This conditional allows backward compatable compilations with
 # PacificBiosciences/blasr_libcpp.
 EXTRA_LDLIBS = -lpbbam -lhts -lz -lpthread
+endif

--- a/test/cpp/Makefile
+++ b/test/cpp/Makefile
@@ -1,3 +1,4 @@
+.PHONY: all check test_target_hit test_alngraph test_alignment test_simple_aligner
 # project source code
 SRCDIR := ../../src/cpp
 
@@ -8,10 +9,11 @@ include gtest.mk
 GTEST_CPPFLAGS += -isystem $(GTEST_DIR)/include
 GTEST_CXXFLAGS += -g -Wall -Wextra -pthread
 
-CXXFLAGS := -O3 -std=c++11 $(INCDIRS) -I $(SRCDIR) \
-		    -I $(BOOST_HEADERS) \
-			-I $(GTEST_DIR)/include \
-			-I $(GTEST_DIR)
+INCDIRS := -I$(PBDATA) -I$(BLASR) -I$(BOOST_HEADERS) -I$(GTEST_DIR)/include -I$(GTEST_DIR) $(EXTRA_INCDIRS)
+LDFLAGS := -L$(PBDATA) -L$(BLASR) $(EXTRA_LDFLAGS)
+LDLIBS := -lpbdata -lblasr -lpthread ${EXTRA_LDLIBS}
+
+CXXFLAGS := -O3 -std=c++11 $(INCDIRS) -I$(SRCDIR)
 
 GTEST_OBJECTS := gtest-all.o gtest_main.o
 DAZCON_OBJECTS := $(SRCDIR)/DB.o $(SRCDIR)/align.o $(SRCDIR)/Alignment.o \
@@ -20,13 +22,6 @@ DAZCON_OBJECTS := $(SRCDIR)/DB.o $(SRCDIR)/align.o $(SRCDIR)/Alignment.o \
 PBDAGCON_OBJECTS := $(SRCDIR)/AlnGraphBoost.o $(SRCDIR)/Alignment.o \
 					$(SRCDIR)/SimpleAligner.o 
 vpath %.cc $(gtest_version)/src
-
-# Special case, accomodate migration to BAM
-ifeq ($(wildcard $(PBBAM)/*),)
-LDLIBS = -lpbdata -lblasr -lpthread
-else
-LDLIBS = -lpbdata -lblasr -lpbbam -lhts -lz -lpthread
-endif
 
 BUILDMSG = "=== Building $@ ==="
 
@@ -38,27 +33,27 @@ check: test_target_hit test_alngraph test_alignment test_simple_aligner
 
 test_target_hit: $(GTEST_OBJECTS) $(DAZCON_OBJECTS) TargetHitTest.o 
 	@echo $(BUILDMSG)
-	@$(CXX) $^ -o $@ -lpthread
+	$(CXX) $^ -o $@ -lpthread
 	./$@
 
 test_target: $(GTEST_OBJECTS) $(DAZCON_OBJECTS) TargetTest.o
 	@echo $(BUILDMSG)
-	@$(CXX) $^ -o $@ -lpthread
+	$(CXX) $^ -o $@ -lpthread
 	./$@
 
 test_alngraph: $(GTEST_OBJECTS) $(PBDAGCON_OBJECTS) AlnGraphBoostTest.o
 	@echo $(BUILDMSG)
-	@$(CXX) $^ -static -o $@ $(LDFLAGS) $(LDLIBS)
+	$(CXX) $^ -static -o $@ $(LDFLAGS) $(LDLIBS)
 	./$@
 
 test_alignment: $(GTEST_OBJECTS) $(PBDAGCON_OBJECTS) AlignmentTest.o
 	@echo $(BUILDMSG)
-	@$(CXX) $^ -static -o $@ $(LDFLAGS) $(LDLIBS)
+	$(CXX) $^ -static -o $@ $(LDFLAGS) $(LDLIBS)
 	./$@
 
 test_simple_aligner: $(GTEST_OBJECTS) $(PBDAGCON_OBJECTS) SimpleAlignerTest.o
 	@echo $(BUILDMSG)
-	@$(CXX) $^ -static -o $@ $(LDFLAGS) $(LDLIBS)
+	$(CXX) $^ -static -o $@ $(LDFLAGS) $(LDLIBS)
 	./$@
 
 $(SRCDIR)/AlnGraphBoost.o: $(BOOST_HEADERS)
@@ -68,7 +63,7 @@ $(GTEST_OBJECTS): $(GTEST_DIR)
 
 $(BOOST_HEADERS):
 	@echo Fetching boost headers from $(URI)
-	@cd $(SRCDIR)/third-party && $(GET_BOOST)
+	cd $(SRCDIR)/third-party && $(GET_BOOST)
 
 $(GTEST_DIR):
 	@echo Fetching gtest from $(gtest_uri)


### PR DESCRIPTION
* PacificBiosciences/blasr_libcpp#1
* PacificBiosciences/pbdagcon#10

Both pbdagcon and blasr_libcpp can now be built from github source within PacBio, like so:
```sh
p4 describe 153448
cd smrtanalysis/bioinformatics; make -f ext.makefile
```
Try it! That currently uses the `ext` branch of my own (`pb-cdunn`) forks of these two packages, but we can easily switch to the official PacificBiosciences repos soon.