### PR TITLE
pre-configure blasr_libcpp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,9 @@ update-submodule:
 	git submodule update --init
 
 build-submodule:
-	$(MAKE) -C blasr_libcpp/pbdata nopbbam=1 mklibconfig
-	$(MAKE) -C blasr_libcpp/alignment -f simple.mk nohdf=1
-	$(MAKE) -C blasr_libcpp/pbdata nopbbam=1
+	cd blasr_libcpp; NOHDF=1 NOPBBAM=1 ./configure.py
+	$(MAKE) -C blasr_libcpp/pbdata -f build.mk all
+	$(MAKE) -C blasr_libcpp/alignment -f build.mk all
 
 submodule-clean:
 	$(RM) -r blasr_libcpp


### PR DESCRIPTION
I will do the same thing for blasr and pbdagcon, but it takes time. I always have to copy herb's makefile templates, which is a moving target. And testing with the nightly releasebuild has been very difficult and time-consuming, though it's gotten a little better.

These commits of blasr_libcpp and pbdagcon will not work in mobs yet. The buildctl.sh files need to be modified to run 'configure.py', and that script needs to be updated to match the variables passed in by mobs. And that will require testing.

After that, I'll look at bioinformatics/Makefile, which is very simple and by far the easiest thing to work with. Oh, actually I have to work with that first, since mobs does not yet persist its git repos.

Then I'll get back to the Swarm tests which were broken by a variety of recent changes (nightly build and hdf refactoring for bax2bam). I also learned that the blasr_libcpp unittests have some failures. Swarm-testing is another pretty simple system to work with.

Worst case, we can revert if GitHub. We are using SHA1s for blasr_libcpp already. So I'll merge this immediately.