### PR TITLE
use static linkage with blasr_libcpp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ update-submodule:
 
 build-submodule:
 	cd blasr_libcpp; NOHDF=1 NOPBBAM=1 ./configure.py
-	$(MAKE) -C blasr_libcpp/pbdata -f build.mk all
-	$(MAKE) -C blasr_libcpp/alignment -f build.mk all
+	$(MAKE) -C blasr_libcpp/pbdata libpbdata.a
+	$(MAKE) -C blasr_libcpp/alignment libblasr.a
 
 submodule-clean:
 	$(RM) -r blasr_libcpp


### PR DESCRIPTION
Most changes are in blasr_libcpp. By targeting only the static libs, we do not need `-Wl,-Bstatic`, etc.