### PR TITLE
more specific vpath

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -233,7 +233,8 @@ def write_makefile(build_dir_root, src_dir_root, makefilename, relpath):
     src_dir = os.path.join(src_dir_root, relpath)
     build_dir = os.path.join(build_dir_root, relpath)
     content = """\
-VPATH:=%(src_dir)s
+vpath %%.cpp %(src_dir)s
+vpath %%.c %(src_dir)s
 include %(src_dir)s/%(makefilename)s
 """ %dict(makefilename=makefilename, src_dir=src_dir)
     mkdirs(build_dir)

--- a/test/cpp/makefile
+++ b/test/cpp/makefile
@@ -4,7 +4,6 @@ all:
 THISDIR:=$(dir $(lastword ${MAKEFILE_LIST}))
 -include ${CURDIR}/../../defines.mk
 SRCDIR := ${THISDIR}
-VPATH:=${VPATH}:${THISDIR}/../../src/cpp
 
 INCDIRS := . \
 	${SRCDIR} \
@@ -73,6 +72,8 @@ testexes   := $(filter-out ${broken_testexes},${testexes})
 ldp+=${LIBBLASR_LIB}:${LIBPBDATA_LIB}:${LIBPBIHDF_LIB}:${PBBAM_LIB}:${HDF5_LIB}:${HTSLIB_LIB}:${ZLIB_LIB}:${LD_LIBRARY_PATH}
 #export LD_LIBRARY_PATH
 
+vpath %.c ${THISDIR}/../../src/cpp
+vpath %.cpp ${THISDIR}/../../src/cpp
 vpath %.cc ${GTEST_SRC}
 
 BUILDMSG = "=== Building $@ ==="


### PR DESCRIPTION
Fixes a corner case, where the project will built in the source-tree and
then built again in an external build-dir. Otherwise, DB.o could come
from the wrong build.