### PR TITLE
PR to note that -lrt required on CentOS 6

### DIFF
--- a/src/cpp/makefile
+++ b/src/cpp/makefile
@@ -31,6 +31,8 @@ LIBDIRS := \
 	${GCC_LIB} \
 	${ZLIB_LIB}
 LDLIBS+= \
+# On CentOS 6.x, this fails to compile unless -lrt is added to the link flags
+# cf. https://github.com/PacificBiosciences/blasr/issues/88
 	${LIBBLASR_LIBFLAGS} \
 	${LIBPBDATA_LIBFLAGS} \
 	${LIBPBIHDF_LIBFLAGS} \


### PR DESCRIPTION
Without that addition to the linking flags, the build fails like this:

g++  -fPIC -I/apps/well/isoseq/sa5.1.0/include -D_GNU_SOURCE  -fPIC -I/apps/well/isoseq/sa5.1.0/include -D_GNU_SOURCE  -fPIC -I/apps/well/isoseq/sa5.1.0/include -D_GNU_SOURCE -O3 -std=c++14 -Wall -Wuninitialized -pedantic -MMD -MP -I/gpfs0/apps/src/build/isoseq/sa5.1.0/pitchfork/workspace/dazzdb -I/gpfs0/apps/src/build/isoseq/sa5.1.0/pitchfork/workspace/daligner -I/apps/well/isoseq/sa5.1.0/include/alignment -I/apps/well/isoseq/sa5.1.0/include/pbdata -I/apps/well/isoseq/sa5.1.0/include -I/apps/well/isoseq/sa5.1.0/include -I/apps/well/isoseq/sa5.1.0/include -I/apps/well/isoseq/sa5.1.0/src/htslib/include -isystem/apps/well/isoseq/sa5.1.0/include -isystem/gpfs0/apps/src/build/isoseq/sa5.1.0/pitchfork/workspace/pbdagcon/src/cpp//third-party  -c -o SimpleAligner.o /gpfs0/apps/src/build/isoseq/sa5.1.0/pitchfork/workspace/pbdagcon/src/cpp/SimpleAligner.cpp
g++  -fPIC -I/apps/well/isoseq/sa5.1.0/include -D_GNU_SOURCE  -fPIC -I/apps/well/isoseq/sa5.1.0/include -D_GNU_SOURCE  -fPIC -I/apps/well/isoseq/sa5.1.0/include -D_GNU_SOURCE -o pbdagcon Alignment.o AlnGraphBoost.o BlasrM5AlnProvider.o main.o SimpleAligner.o  -L/apps/well/isoseq/sa5.1.0/lib -L/apps/well/isoseq/sa5.1.0/lib64 -static-libstdc++ -L /apps/well/isoseq/sa5.1.0/lib -L /apps/well/isoseq/sa5.1.0/lib -L /apps/well/isoseq/sa5.1.0/lib -L /apps/well/isoseq/sa5.1.0/lib -L /apps/well/isoseq/sa5.1.0/lib -L /apps/well/isoseq/sa5.1.0/src/htslib/lib  -lblasr -lpbdata -lpbihdf -lpbbam -lhdf5_cpp -lhdf5 -lhts -lz -lpthread
/apps/well/isoseq/sa5.1.0/lib/libblasr.so: error: undefined reference to 'clock_gettime'
collect2: error: ld returned 1 exit status
make[3]: *** [pbdagcon] Error 1
make[3]: Leaving directory `/gpfs0/apps/src/build/isoseq/sa5.1.0/pitchfork/workspace/pbdagcon/build/src/cpp'
make[2]: *** [cpp] Error 2
make[2]: Leaving directory `/gpfs0/apps/src/build/isoseq/sa5.1.0/pitchfork/workspace/pbdagcon/build'
make[1]: *** [/gpfs0/apps/src/build/isoseq/sa5.1.0/pitchfork/workspace/pbdagcon/build/src/cpp/pbdagcon] Error 2
make[1]: Leaving directory `/gpfs0/apps/src/build/isoseq/sa5.1.0/pitchfork/ports/pacbio/pbdagcon'
make: *** [pbdagcon] Error 2